### PR TITLE
fix: Cast to unicode string for making ascii-encoding work

### DIFF
--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -524,8 +524,8 @@ class SerialLibrary:
         """
         if size is not None:
             size = float(size)
-        if terminator != LF:
-            terminator = self._encode(terminator)
+        if isinstance(terminator, (bytes, bytearray)):
+            raise TypeError("Terminator type: {}".format(terminator.__class__.__name__))
         return self._decode(
             self._port(port_locator).read_until(terminator=terminator, size=size),
             encoding)


### PR DESCRIPTION
AttributeError: 'bytes' object has no attribute 'encode'